### PR TITLE
Remplacer les statuts de projet obsolètes

### DIFF
--- a/app/services/moodboardService.ts
+++ b/app/services/moodboardService.ts
@@ -201,9 +201,9 @@ export const moodboardService = {
 
     // Business rule: can't delete moodboards that are awaiting client or completed
     if (
-      moodboard.status === "awaiting_client" ||
-      moodboard.status === "completed" ||
-      moodboard.status === "payment_pending"
+      moodboard.status === MODULE_STATUS.AWAITING_CLIENT ||
+      moodboard.status === MODULE_STATUS.COMPLETED ||
+      moodboard.status === MODULE_STATUS.PAYMENT_PENDING
     ) {
       throw new Error(
         "Cannot delete moodboards that are awaiting client response, payment pending, or completed"

--- a/app/services/selectionService.ts
+++ b/app/services/selectionService.ts
@@ -1,5 +1,6 @@
 import { selectionImageRepository } from "~/repositories/selectionImageRepository";
 import { selectionRepository } from "~/repositories/selectionRepository";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   IPagination,
   ISelectionFilters,
@@ -28,11 +29,11 @@ export const selectionService = {
     // Business logic: sort by status priority
     return selections.sort((a, b) => {
       const statusOrder = {
-        draft: 0,
-        awaiting_client: 1,
-        revision_requested: 2,
-        payment_pending: 3,
-        completed: 4,
+        [MODULE_STATUS.DRAFT]: 0,
+        [MODULE_STATUS.AWAITING_CLIENT]: 1,
+        [MODULE_STATUS.REVISION_REQUESTED]: 2,
+        [MODULE_STATUS.PAYMENT_PENDING]: 3,
+        [MODULE_STATUS.COMPLETED]: 4,
       };
       return statusOrder[a.status] - statusOrder[b.status];
     });
@@ -166,7 +167,7 @@ export const selectionService = {
 
     // If shouldValidate is explicitly provided, override the status
     if (shouldValidate !== undefined) {
-      finalUpdates.status = shouldValidate ? "awaiting_client" : "draft";
+      finalUpdates.status = shouldValidate ? MODULE_STATUS.AWAITING_CLIENT : MODULE_STATUS.DRAFT;
     }
 
     // If status is provided in updates, use it (allows direct status control)
@@ -230,7 +231,7 @@ export const selectionService = {
     selectionCache.delete(existingSelection.project_id);
 
     // Project is considered updated when selection is sent to client
-    const projectUpdated = finalUpdates.status === "awaiting_client";
+    const projectUpdated = finalUpdates.status === MODULE_STATUS.AWAITING_CLIENT;
 
     return { selection: selectionWithDetails, projectUpdated };
   },
@@ -242,7 +243,7 @@ export const selectionService = {
     const selection = await this.getSelectionById(id);
 
     // Business rule: can only delete selections that are not completed (validated by client)
-    if (selection.status === "completed") {
+    if (selection.status === MODULE_STATUS.COMPLETED) {
       throw new Error(
         "Cannot delete selections that have been validated by the client"
       );

--- a/app/stores/admin/gallery.ts
+++ b/app/stores/admin/gallery.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   Gallery,
   GalleryFormData,
@@ -39,8 +40,8 @@ export const useGalleryStore = defineStore("gallery", () => {
   const canEdit = computed(() => {
     if (!gallery.value) return true;
     return (
-      gallery.value.status === "draft" ||
-      gallery.value.status === "revision_requested"
+      gallery.value.status === MODULE_STATUS.DRAFT ||
+      gallery.value.status === MODULE_STATUS.REVISION_REQUESTED
     );
   });
 
@@ -157,7 +158,7 @@ export const useGalleryStore = defineStore("gallery", () => {
 
       const result = await galleryService.createGallery(
         data,
-        galleryData.status === "awaiting_client"
+        galleryData.status === MODULE_STATUS.AWAITING_CLIENT
       );
 
       // Update project if needed (only for non-free projects)
@@ -222,7 +223,7 @@ export const useGalleryStore = defineStore("gallery", () => {
       const result = await galleryService.updateGallery(
         galleryId,
         data,
-        galleryData.status === "awaiting_client"
+        galleryData.status === MODULE_STATUS.AWAITING_CLIENT
       );
 
       // Update project if needed (only for non-free projects)

--- a/app/stores/admin/moodboard.ts
+++ b/app/stores/admin/moodboard.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { moodboardService } from "~/services/moodboardService";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   MoodboardFormData,
   MoodboardWithDetails,
@@ -19,8 +20,8 @@ export const useMoodboardStore = defineStore("moodboard", () => {
   const canEdit = computed(
     () =>
       !moodboard.value ||
-      moodboard.value.status === "draft" ||
-      moodboard.value.status === "revision_requested"
+      moodboard.value.status === MODULE_STATUS.DRAFT ||
+      moodboard.value.status === MODULE_STATUS.REVISION_REQUESTED
   );
   const imageCount = computed(() => moodboard.value?.imageCount || 0);
   const hasImages = computed(() => imageCount.value > 0);
@@ -76,7 +77,7 @@ export const useMoodboardStore = defineStore("moodboard", () => {
 
       const result = await moodboardService.createMoodboard(
         data,
-        moodboardData.status === "awaiting_client"
+        moodboardData.status === MODULE_STATUS.AWAITING_CLIENT
       );
       moodboard.value = result.moodboard;
 
@@ -131,7 +132,7 @@ export const useMoodboardStore = defineStore("moodboard", () => {
       const result = await moodboardService.updateMoodboard(
         moodboardId,
         data,
-        moodboardData.status === "awaiting_client"
+        moodboardData.status === MODULE_STATUS.AWAITING_CLIENT
       );
       moodboard.value = result.moodboard;
 

--- a/app/stores/admin/projects.ts
+++ b/app/stores/admin/projects.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { projectService } from "~/services/projectService";
+import type { ProjectStatus } from "~/types/status";
 import type {
   IProjectFilters,
   ProjectFormData,
@@ -20,7 +21,7 @@ export const useProjectsStore = defineStore("projects", () => {
 
   // Filter State
   const searchQuery = ref("");
-  const statusFilter = ref<"draft" | "in_progress" | "completed" | null>(null);
+  const statusFilter = ref<ProjectStatus | null>(null);
   const sortOrder = ref<
     | "title_asc"
     | "title_desc"

--- a/app/stores/admin/proposal.ts
+++ b/app/stores/admin/proposal.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { proposalService } from "~/services/proposalService";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   ProjectPaymentData,
   Proposal,
@@ -21,8 +22,8 @@ export const useProposalStore = defineStore("proposal", () => {
   const exists = computed(() => proposal.value !== null);
   const canEdit = computed(
     () =>
-      proposal.value?.status === "draft" ||
-      proposal.value?.status === "revision_requested"
+      proposal.value?.status === MODULE_STATUS.DRAFT ||
+      proposal.value?.status === MODULE_STATUS.REVISION_REQUESTED
   );
   const formattedPrice = computed(() => formatPrice(proposal.value?.price));
   const formattedDepositAmount = computed(() =>

--- a/app/stores/admin/selection.ts
+++ b/app/stores/admin/selection.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { selectionService } from "~/services/selectionService";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   SelectionFormData,
   SelectionImage,
@@ -77,8 +78,8 @@ export const useSelectionStore = defineStore("selection", () => {
   const canEdit = computed(
     () =>
       !selection.value ||
-      selection.value.status === "draft" ||
-      selection.value.status === "revision_requested"
+      selection.value.status === MODULE_STATUS.DRAFT ||
+      selection.value.status === MODULE_STATUS.REVISION_REQUESTED
   );
   const imageCount = computed(() => selection.value?.imageCount || 0);
   const selectedCount = computed(() => selection.value?.selectedCount || 0);
@@ -294,7 +295,7 @@ export const useSelectionStore = defineStore("selection", () => {
 
       const result = await selectionService.createSelection(
         data,
-        selectionData.status === "awaiting_client"
+        selectionData.status === MODULE_STATUS.AWAITING_CLIENT
       );
       selection.value = result.selection;
 
@@ -342,7 +343,7 @@ export const useSelectionStore = defineStore("selection", () => {
       const result = await selectionService.updateSelection(
         selectionId,
         data,
-        selectionData.status === "awaiting_client"
+        selectionData.status === MODULE_STATUS.AWAITING_CLIENT
       );
       selection.value = result.selection;
 

--- a/app/stores/public/gallery.ts
+++ b/app/stores/public/gallery.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   ClientGalleryAccess,
   GalleryImageWithSignedUrl,
@@ -209,14 +210,7 @@ export const useClientGalleryStore = defineStore("clientGallery", () => {
     }
   };
 
-  const updateGalleryStatus = (
-    status:
-      | "draft"
-      | "awaiting_client"
-      | "revision_requested"
-      | "completed"
-      | "payment_pending"
-  ) => {
+  const updateGalleryStatus = (status: typeof MODULE_STATUS[keyof typeof MODULE_STATUS]) => {
     if (gallery.value) {
       gallery.value.status = status;
     }

--- a/app/stores/public/moodboard.ts
+++ b/app/stores/public/moodboard.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   ClientMoodboardAccess,
   MoodboardImageWithInteractions,
@@ -43,8 +44,8 @@ export const useClientMoodboardStore = defineStore("clientMoodboard", () => {
   const canInteract = computed(() => {
     if (!moodboard.value) return false;
     return (
-      moodboard.value.status !== "completed" &&
-      moodboard.value.status !== "revision_requested"
+      moodboard.value.status !== MODULE_STATUS.COMPLETED &&
+      moodboard.value.status !== MODULE_STATUS.REVISION_REQUESTED
     );
   });
 

--- a/app/stores/public/selection.ts
+++ b/app/stores/public/selection.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { MODULE_STATUS } from "~/types/status";
 import type {
   ClientSelectionAccess,
   SelectionImageWithSelection,
@@ -48,8 +49,8 @@ export const useClientSelectionStore = defineStore("clientSelection", () => {
   const canInteract = computed(() => {
     if (!selection.value) return false;
     return (
-      selection.value.status !== "completed" &&
-      selection.value.status !== "revision_requested"
+      selection.value.status !== MODULE_STATUS.COMPLETED &&
+      selection.value.status !== MODULE_STATUS.REVISION_REQUESTED
     );
   });
 

--- a/server/api/moodboard/client/[id]/request-revisions.post.ts
+++ b/server/api/moodboard/client/[id]/request-revisions.post.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
+import { MODULE_STATUS } from "~/types/status";
 import type { ClientRevisionRequest } from "~/types/moodboard";
 
 export default defineEventHandler(async (event) => {
@@ -43,7 +44,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Check if moodboard can have revisions requested
-    if (moodboard.status !== "awaiting_client") {
+    if (moodboard.status !== MODULE_STATUS.AWAITING_CLIENT) {
       throw createError({
         statusCode: 403,
         statusMessage:

--- a/server/api/moodboard/client/[id]/validate.post.ts
+++ b/server/api/moodboard/client/[id]/validate.post.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
+import { MODULE_STATUS } from "~/types/status";
 
 export default defineEventHandler(async (event) => {
   const moodboardId = getRouterParam(event, "id");
@@ -41,7 +42,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Check if moodboard can be validated
-    if (moodboard.status !== "awaiting_client") {
+    if (moodboard.status !== MODULE_STATUS.AWAITING_CLIENT) {
       throw createError({
         statusCode: 403,
         statusMessage:

--- a/server/api/moodboard/client/[id]/verify.post.ts
+++ b/server/api/moodboard/client/[id]/verify.post.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
+import { MODULE_STATUS } from "~/types/status";
 import type { ClientPasswordVerification } from "~/types/moodboard";
 
 export default defineEventHandler(async (event) => {
@@ -46,9 +47,9 @@ export default defineEventHandler(async (event) => {
 
     // Check if moodboard is accessible to clients
     if (
-      moodboard.status !== "awaiting_client" &&
-      moodboard.status !== "completed" &&
-      moodboard.status !== "revision_requested"
+      moodboard.status !== MODULE_STATUS.AWAITING_CLIENT &&
+      moodboard.status !== MODULE_STATUS.COMPLETED &&
+      moodboard.status !== MODULE_STATUS.REVISION_REQUESTED
     ) {
       console.error(
         "[DEBUG] Verify API - Moodboard not accessible, status:",

--- a/server/api/selection/client/[id].get.ts
+++ b/server/api/selection/client/[id].get.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
+import { MODULE_STATUS } from "~/types/status";
 import type { ClientSelectionAccess } from "~/types/selection";
 
 export default defineEventHandler(
@@ -50,7 +51,7 @@ export default defineEventHandler(
       }
 
       // Check accessibility
-      if (selection.status === "draft") {
+      if (selection.status === MODULE_STATUS.DRAFT) {
         throw createError({
           statusCode: 403,
           message: "Sélection non accessible",

--- a/server/api/selection/client/[id]/request-revisions.post.ts
+++ b/server/api/selection/client/[id]/request-revisions.post.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
+import { MODULE_STATUS } from "~/types/status";
 import type { ClientRevisionRequest } from "~/types/selection";
 
 export default defineEventHandler(async (event) => {
@@ -43,7 +44,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Check if selection can have revisions requested
-    if (selection.status !== "awaiting_client") {
+    if (selection.status !== MODULE_STATUS.AWAITING_CLIENT) {
       throw createError({
         statusCode: 403,
         statusMessage:

--- a/server/api/selection/client/[id]/validate.post.ts
+++ b/server/api/selection/client/[id]/validate.post.ts
@@ -1,5 +1,6 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
 import { z } from "zod";
+import { MODULE_STATUS } from "~/types/status";
 
 const validateSchema = z.object({
   selectedImages: z.array(z.string().uuid()),
@@ -59,7 +60,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Check if selection can be validated
-    if (selection.status !== "awaiting_client") {
+    if (selection.status !== MODULE_STATUS.AWAITING_CLIENT) {
       throw createError({
         statusCode: 403,
         statusMessage:

--- a/server/api/selection/client/[id]/verify.post.ts
+++ b/server/api/selection/client/[id]/verify.post.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseServiceRole } from "#supabase/server";
+import { MODULE_STATUS } from "~/types/status";
 import type { ClientPasswordVerification } from "~/types/selection";
 
 export default defineEventHandler(async (event) => {
@@ -45,9 +46,9 @@ export default defineEventHandler(async (event) => {
 
     // Check if selection is accessible to clients
     if (
-      selection.status !== "awaiting_client" &&
-      selection.status !== "completed" &&
-      selection.status !== "revision_requested"
+      selection.status !== MODULE_STATUS.AWAITING_CLIENT &&
+      selection.status !== MODULE_STATUS.COMPLETED &&
+      selection.status !== MODULE_STATUS.REVISION_REQUESTED
     ) {
       throw createError({
         statusCode: 403,


### PR DESCRIPTION
Replace hardcoded module and project status strings with `MODULE_STATUS` and `ProjectStatus` constants for improved maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-313639a6-17e8-4629-9b22-f48c1d16fffe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-313639a6-17e8-4629-9b22-f48c1d16fffe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

